### PR TITLE
Add a FPS slider to options menu

### DIFF
--- a/src/scenes/ui/fps_slider.tscn
+++ b/src/scenes/ui/fps_slider.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=11 format=3 uid="uid://dqqi0ixflctdy"]
+
+[ext_resource type="Texture2D" uid="uid://ckxgkwoiqj3on" path="res://assets/images/ui/slider_button.png" id="1_rgon2"]
+[ext_resource type="Texture2D" uid="uid://bju77jxdk7mwl" path="res://assets/images/ui/slider_button_hover.png" id="2_54ihq"]
+[ext_resource type="Texture2D" uid="uid://dnish8tdwujum" path="res://assets/images/ui/slider_button_held.png" id="3_4l2yy"]
+[ext_resource type="Texture2D" uid="uid://bektpxlme7plh" path="res://assets/images/ui/slider_bar.png" id="4_pfhvi"]
+[ext_resource type="Texture2D" uid="uid://ci82om0gcdj02" path="res://assets/images/ui/slider_bar_filled.png" id="5_jvm01"]
+[ext_resource type="Texture2D" uid="uid://cieae2burfs2c" path="res://assets/images/ui/slider_highlight.png" id="6_q2uf3"]
+[ext_resource type="Script" path="res://scripts/ui/fps_slider.gd" id="7_06ord"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_n4eiu"]
+texture = ExtResource("4_pfhvi")
+texture_margin_left = 3.0
+texture_margin_top = 3.0
+texture_margin_right = 3.0
+texture_margin_bottom = 3.0
+region_rect = Rect2(0, 0, 11, 7)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_i10qj"]
+texture = ExtResource("5_jvm01")
+texture_margin_left = 3.0
+texture_margin_top = 2.0
+texture_margin_right = 3.0
+texture_margin_bottom = 4.0
+region_rect = Rect2(0, 0, 11, 7)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_3fvdy"]
+texture = ExtResource("6_q2uf3")
+texture_margin_left = 3.0
+texture_margin_top = 2.0
+texture_margin_right = 3.0
+texture_margin_bottom = 4.0
+
+[node name="VolumeSlider" type="HSlider"]
+size_flags_horizontal = 3
+theme_override_icons/grabber = ExtResource("1_rgon2")
+theme_override_icons/grabber_highlight = ExtResource("2_54ihq")
+theme_override_icons/grabber_disabled = ExtResource("3_4l2yy")
+theme_override_icons/tick = ExtResource("1_rgon2")
+theme_override_styles/slider = SubResource("StyleBoxTexture_n4eiu")
+theme_override_styles/grabber_area = SubResource("StyleBoxTexture_i10qj")
+theme_override_styles/grabber_area_highlight = SubResource("StyleBoxTexture_3fvdy")
+max_value = 1.0
+step = 0.005
+ticks_on_borders = true
+script = ExtResource("7_06ord")
+
+[connection signal="drag_ended" from="." to="." method="_on_drag_ended"]
+[connection signal="drag_started" from="." to="." method="_on_drag_started"]
+[connection signal="value_changed" from="." to="." method="_on_value_changed"]

--- a/src/scenes/ui/menu/options_menu.tscn
+++ b/src/scenes/ui/menu/options_menu.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://c0vf1vyo26r55"]
+[gd_scene load_steps=8 format=3 uid="uid://c0vf1vyo26r55"]
 
 [ext_resource type="PackedScene" uid="uid://dt7ylcp3vogvt" path="res://scenes/ui/menu/menu.tscn" id="1_w3j1j"]
 [ext_resource type="Script" path="res://scripts/ui/menu/options_menu.gd" id="1_wjxn1"]
 [ext_resource type="LabelSettings" uid="uid://cl1yg37xye2ku" path="res://assets/resources/label_settings.tres" id="3_t0dhi"]
 [ext_resource type="PackedScene" uid="uid://l4uy665qgi6n" path="res://scenes/ui/ui_button.tscn" id="5_jwcs2"]
+[ext_resource type="PackedScene" uid="uid://dqqi0ixflctdy" path="res://scenes/ui/fps_slider.tscn" id="5_mpshi"]
 [ext_resource type="PackedScene" uid="uid://dv7orepl8b082" path="res://scenes/ui/volume_slider.tscn" id="6_gllis"]
 [ext_resource type="PackedScene" uid="uid://ciguail0coyfn" path="res://scenes/ui/ui_fullscreen_button.tscn" id="7_t2eu6"]
 
@@ -49,20 +50,36 @@ autowrap_mode = 3
 layout_mode = 2
 audio_bus_name = "Music"
 
-[node name="FullscreenButton" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="1" instance=ExtResource("7_t2eu6")]
+[node name="FpsSliderContainer" type="VBoxContainer" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="1"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/AspectRatioContainer/Items/Buttons/FpsSliderContainer" index="0"]
+custom_minimum_size = Vector2(70, 0)
+layout_mode = 2
+text = "FPS:"
+label_settings = ExtResource("3_t0dhi")
+autowrap_mode = 3
+
+[node name="VolumeSlider" parent="MarginContainer/AspectRatioContainer/Items/Buttons/FpsSliderContainer" index="1" instance=ExtResource("5_mpshi")]
+layout_mode = 2
+
+[node name="FullscreenButton" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="2" instance=ExtResource("7_t2eu6")]
 unique_name_in_owner = true
 layout_mode = 2
 text = "MENU_OPTIONS_FULLSCREEN"
 icon = null
 
-[node name="Language" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="2" instance=ExtResource("5_jwcs2")]
+[node name="OptionsContainer" type="HBoxContainer" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="3"]
+layout_mode = 2
+
+[node name="Language" parent="MarginContainer/AspectRatioContainer/Items/Buttons/OptionsContainer" index="0" instance=ExtResource("5_jwcs2")]
 unique_name_in_owner = true
 layout_mode = 2
 text = "MENU_OPTIONS_LANGUAGE"
 
-[node name="ResetProgress" parent="MarginContainer/AspectRatioContainer/Items/Buttons" index="3" instance=ExtResource("5_jwcs2")]
+[node name="ResetProgress" parent="MarginContainer/AspectRatioContainer/Items/Buttons/OptionsContainer" index="1" instance=ExtResource("5_jwcs2")]
 layout_mode = 2
 text = "MENU_RESET_PROGRESS"
 
-[connection signal="pressed" from="MarginContainer/AspectRatioContainer/Items/Buttons/Language" to="." method="_on_language_pressed"]
-[connection signal="pressed" from="MarginContainer/AspectRatioContainer/Items/Buttons/ResetProgress" to="." method="_on_reset_progress_pressed"]
+[connection signal="pressed" from="MarginContainer/AspectRatioContainer/Items/Buttons/OptionsContainer/Language" to="." method="_on_language_pressed"]
+[connection signal="pressed" from="MarginContainer/AspectRatioContainer/Items/Buttons/OptionsContainer/ResetProgress" to="." method="_on_reset_progress_pressed"]

--- a/src/scripts/ui/fps_slider.gd
+++ b/src/scripts/ui/fps_slider.gd
@@ -10,7 +10,7 @@ var fps_limit_value: int
 func _ready():
 	max_value = client_hz * 2
 	value = client_hz
-	label.text = slide_name + str(client_hz)
+	label.text = slide_name + str(int(client_hz))
 
 func _on_value_changed(value):
 	fps_limit_value = value

--- a/src/scripts/ui/fps_slider.gd
+++ b/src/scripts/ui/fps_slider.gd
@@ -1,0 +1,27 @@
+extends HSlider
+#mostly copied from volume slider
+
+@export var slide_name := "FPS limit: "
+@onready var label = $"../Label"
+
+var client_hz = DisplayServer.screen_get_refresh_rate()
+var fps_limit_value: int
+
+func _ready():
+	max_value = client_hz * 2
+	value = client_hz
+	label.text = slide_name + str(client_hz)
+
+func _on_value_changed(value):
+	fps_limit_value = value
+		
+	if fps_limit_value == 0:
+		label.text = slide_name + "∞"
+	else:
+		label.text = slide_name + str(fps_limit_value)
+
+func _on_drag_started():
+	Engine.max_fps = client_hz
+
+func _on_drag_ended(value_changed):
+	Engine.max_fps = fps_limit_value


### PR DESCRIPTION
I made this after I encountered an issue on my Mac, where the game would not have any FPS limit, therefore drawing a lot of power. I believe you fixed that already, but Yolwoocle suggested I could make a PR, so here it is.

The label text for the FPS slider is a fixed string, unlike that of the other option buttons / sliders, just so you know. Though I believe "FPS" does not need any translation anyway.

I made this just for myself initially and it is rather low effort, but yeah. Oh and also, I have no clue how to make proper commits to Godot projects within Github and just changed the files manually, I hope everything works like intended.